### PR TITLE
Add weasyprint dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,9 @@ RUN apt-get update && \
                         libffi-dev \
                         libpython2.7-dev \
                         libpython3.4-dev \
-                        libssl-dev
+                        libssl-dev \
+                        libxml2-dev \
+                        libxslt1-dev
 
 # Locale management
 RUN locale-gen en_US.UTF-8

--- a/spec/Dockerfile_spec.rb
+++ b/spec/Dockerfile_spec.rb
@@ -89,6 +89,8 @@ describe 'Dockerfile' do
         expect(package('libpython2.7-dev')).to be_installed
         expect(package('libpython3.4-dev')).to be_installed
         expect(package('libssl-dev')).to be_installed
+        expect(package('libxml2-dev')).to be_installed
+        expect(package('libxslt1-dev')).to be_installed
     end
 
     describe command('locale') do
@@ -106,4 +108,3 @@ describe 'Dockerfile' do
         command('lsb_release -a').stdout
     end
 end
-


### PR DESCRIPTION
Packages libxml2-dev and libxslt1-dev are needed by [weasyprint](http://weasyprint.org/).